### PR TITLE
fix: persist auth state across page refreshes and display user name i…

### DIFF
--- a/client/src/context/auth-context.tsx
+++ b/client/src/context/auth-context.tsx
@@ -11,20 +11,32 @@ interface AuthContextType {
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
-  const [userType, setUserType] = useState<"artisan" | "customer" | null>(null);
-  const [userName, setUserName] = useState<string | null>(null);
+  const [isLoggedIn, setIsLoggedIn] = useState<boolean>(() => {
+    return localStorage.getItem("auth_logged_in") === "true";
+  });
+  const [userType, setUserType] = useState<"artisan" | "customer" | null>(() => {
+    return (localStorage.getItem("auth_user_type") as "artisan" | "customer") || null;
+  });
+  const [userName, setUserName] = useState<string | null>(() => {
+    return localStorage.getItem("auth_user_name") || null;
+  });
 
   const login = (type: "artisan" | "customer", name: string) => {
     setIsLoggedIn(true);
     setUserType(type);
     setUserName(name);
+    localStorage.setItem("auth_logged_in", "true");
+    localStorage.setItem("auth_user_type", type);
+    localStorage.setItem("auth_user_name", name);
   };
 
   const logout = () => {
     setIsLoggedIn(false);
     setUserType(null);
     setUserName(null);
+    localStorage.removeItem("auth_logged_in");
+    localStorage.removeItem("auth_user_type");
+    localStorage.removeItem("auth_user_name");
   };
 
   return (

--- a/client/src/pages/artisan-login.tsx
+++ b/client/src/pages/artisan-login.tsx
@@ -7,16 +7,19 @@ import { Label } from "@/components/ui/label";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useToast } from "@/hooks/use-toast";
 import { Checkbox } from "@/components/ui/checkbox";
+import { useAuth } from "@/context/auth-context";
 
 export default function ArtisanLogin() {
   const [, setLocation] = useLocation();
   const [step, setStep] = useState<"email" | "password" | "success">("email");
   const [email, setEmail] = useState("");
+  const [name, setName] = useState("");
   const [password, setPassword] = useState("");
   const [showPassword, setShowPassword] = useState(false);
   const [loading, setLoading] = useState(false);
   const [rememberMe, setRememberMe] = useState(false);
   const { toast } = useToast();
+  const { login } = useAuth();
 
   const handleEmailSubmit = async () => {
     if (!email) {
@@ -36,6 +39,10 @@ export default function ArtisanLogin() {
   };
 
   const handleLogin = async () => {
+    if (!name.trim()) {
+      toast({ title: "Error", description: "Please enter your name", variant: "destructive" });
+      return;
+    }
     if (!password) {
       toast({ title: "Error", description: "Please enter your password", variant: "destructive" });
       return;
@@ -44,6 +51,7 @@ export default function ArtisanLogin() {
     setLoading(true);
     try {
       setTimeout(() => {
+        login("artisan", name.trim());
         setStep("success");
         toast({ title: "Welcome back!", description: "Login successful" });
       }, 1000);
@@ -115,6 +123,19 @@ export default function ArtisanLogin() {
               <div className="space-y-4">
                 <div className="p-4 bg-primary/10 rounded-lg">
                   <p className="text-sm text-muted-foreground">Email: <span className="font-semibold text-foreground">{email}</span></p>
+                </div>
+
+                <div>
+                  <Label htmlFor="name" className="text-sm font-medium">Your Name</Label>
+                  <Input
+                    id="name"
+                    type="text"
+                    placeholder="What should we call you?"
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    className="mt-2"
+                    disabled={loading}
+                  />
                 </div>
 
                 <div>

--- a/client/src/pages/customer-login.tsx
+++ b/client/src/pages/customer-login.tsx
@@ -7,16 +7,19 @@ import { Label } from "@/components/ui/label";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useToast } from "@/hooks/use-toast";
 import { Checkbox } from "@/components/ui/checkbox";
+import { useAuth } from "@/context/auth-context";
 
 export default function CustomerLogin() {
   const [, setLocation] = useLocation();
   const [step, setStep] = useState<"email" | "password" | "success">("email");
   const [email, setEmail] = useState("");
+  const [name, setName] = useState("");
   const [password, setPassword] = useState("");
   const [showPassword, setShowPassword] = useState(false);
   const [loading, setLoading] = useState(false);
   const [rememberMe, setRememberMe] = useState(false);
   const { toast } = useToast();
+  const { login } = useAuth();
 
   const handleEmailSubmit = async () => {
     if (!email) {
@@ -36,6 +39,10 @@ export default function CustomerLogin() {
   };
 
   const handleLogin = async () => {
+    if (!name.trim()) {
+      toast({ title: "Error", description: "Please enter your name", variant: "destructive" });
+      return;
+    }
     if (!password) {
       toast({ title: "Error", description: "Please enter your password", variant: "destructive" });
       return;
@@ -44,6 +51,7 @@ export default function CustomerLogin() {
     setLoading(true);
     try {
       setTimeout(() => {
+        login("customer", name.trim());
         setStep("success");
         toast({ title: "Welcome back!", description: "Login successful" });
       }, 1000);
@@ -112,6 +120,19 @@ export default function CustomerLogin() {
               <div className="space-y-4">
                 <div className="p-4 bg-secondary/10 rounded-lg">
                   <p className="text-sm text-muted-foreground">Email: <span className="font-semibold text-foreground">{email}</span></p>
+                </div>
+
+                <div>
+                  <Label htmlFor="name" className="text-sm font-medium">Your Name</Label>
+                  <Input
+                    id="name"
+                    type="text"
+                    placeholder="What should we call you?"
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    className="mt-2"
+                    disabled={loading}
+                  />
                 </div>
 
                 <div>


### PR DESCRIPTION
…n navbar

- Initialize auth state from localStorage on mount
- Write auth data to localStorage on login, clear on logout
- Call login() from auth context in customer and artisan login pages
- Add name field to login flow so navbar shows name instead of email

https://drive.google.com/drive/folders/1PdBY2JHsiOFVRyG8eFgdeaLCBFH1rzCr?usp=sharing
check out the before and after changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist auth across page refreshes and show the user’s name in the navbar for both customer and artisan logins. Auth context now initializes from localStorage and login screens pass the name to `login`.

- **Bug Fixes**
  - Persist `isLoggedIn`, `userType`, and `userName` in `localStorage`; restore on mount and clear on logout.

- **New Features**
  - Added a name field to login; navbar now displays the user’s name instead of email. Customer and artisan pages call `login(type, name)` after successful auth.

<sup>Written for commit 933ee77d57f49f7ba3af9efff3c63eb079c32ac9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

