### PR TITLE
feat: add Order Summary and Checkout Page | NSoC'26

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,16 +1,11 @@
 import "./i18n";
 import { Switch, Route, useLocation } from "wouter";
 import { QueryClientProvider } from "@tanstack/react-query";
-
-
-import { Toaster } from "@/components/ui/toaster";
-import { TooltipProvider } from "@/components/ui/tooltip";
 import { AnimatePresence, motion } from "framer-motion";
 
 import { queryClient } from "./lib/queryClient";
 import { AuthProvider } from "@/context/auth-context";
 import { CartProvider } from "@/context/cart-context";
-
 import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import Navbar from "@/components/navbar";
@@ -33,17 +28,15 @@ import CustomerSignup from "@/pages/customer-signup";
 import CustomerLogin  from "@/pages/customer-login";
 import ArtisanSignup  from "@/pages/artisan-signup";
 import ArtisanLogin   from "@/pages/artisan-login";
-
-
-// ─── Routes ──────────────────────────────────────────────────────────────────
+import Checkout       from "@/pages/checkout";
 
 const AUTH_ROUTES = [
-  { path: "/welcome",          component: Welcome        },
-  { path: "/auth",             component: AuthLanding    },
-  { path: "/customer-signup",  component: CustomerSignup },
-  { path: "/customer-login",   component: CustomerLogin  },
-  { path: "/artisan-signup",   component: ArtisanSignup  },
-  { path: "/artisan-login",    component: ArtisanLogin   },
+  { path: "/welcome",         component: Welcome        },
+  { path: "/auth",            component: AuthLanding    },
+  { path: "/customer-signup", component: CustomerSignup },
+  { path: "/customer-login",  component: CustomerLogin  },
+  { path: "/artisan-signup",  component: ArtisanSignup  },
+  { path: "/artisan-login",   component: ArtisanLogin   },
 ];
 
 const MAIN_ROUTES = [
@@ -55,28 +48,8 @@ const MAIN_ROUTES = [
   { path: "/ai-storytelling",       component: AiStorytelling },
   { path: "/community/stories/:id", component: StoryDetail    },
   { path: "/community",             component: Community      },
+  { path: "/checkout",              component: Checkout       },
 ];
-
-
-// ─── Router ──────────────────────────────────────────────────────────────────
-import NotFound from "@/pages/not-found";
-import Welcome from "@/pages/welcome";
-import Home from "@/pages/home";
-import Marketplace from "@/pages/marketplace";
-import ProductDetail from "./pages/product-detail";
-import Artisans from "@/pages/artisans";
-import ArtisanProfile from "@/pages/artisan-profile";
-import AiStorytelling from "@/pages/ai-storytelling";
-import Community from "@/pages/community";
-import StoryDetail from "@/pages/story-detail";
-import AuthLanding from "@/pages/auth-landing";
-import CustomerSignup from "@/pages/customer-signup";
-import CustomerLogin from "@/pages/customer-login";
-import ArtisanSignup from "@/pages/artisan-signup";
-import ArtisanLogin from "@/pages/artisan-login";
-import Navbar from "@/components/navbar";
-import Footer from "@/components/footer";
-import ShoppingCart from "@/components/shopping-cart";
 
 function Router() {
   const [location] = useLocation();
@@ -91,7 +64,6 @@ function Router() {
         {() => (
           <div className="min-h-screen bg-background">
             <Navbar />
-
             <AnimatePresence mode="wait">
               <motion.main
                 key={location}
@@ -108,7 +80,6 @@ function Router() {
                 </Switch>
               </motion.main>
             </AnimatePresence>
-
             <Footer />
             <ShoppingCart />
             <BackToTop />
@@ -118,9 +89,6 @@ function Router() {
     </Switch>
   );
 }
-
-
-// ─── App ─────────────────────────────────────────────────────────────────────
 
 export default function App() {
   return (

--- a/client/src/components/navbar.tsx
+++ b/client/src/components/navbar.tsx
@@ -1,9 +1,7 @@
 import { Link, useLocation } from "wouter";
 import { LogOut, Menu, Search, ShoppingBag } from "lucide-react";
 import { useState } from "react";
-import { useCart } from "@/context/cart-context";
 import { useTranslation } from "react-i18next";
-
 import { useCart } from "@/context/cart-context";
 import { useAuth } from "@/context/auth-context";
 import { Button } from "@/components/ui/button";

--- a/client/src/components/product-card.tsx
+++ b/client/src/components/product-card.tsx
@@ -5,7 +5,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api";
 import { useToast } from "@/hooks/use-toast";
-import { useCart } from "@/App";
+import { useCart } from "@/context/cart-context";
 import { getCategoryFallbackImage, getProductImage } from "@/lib/product-image-utils";
 import { Product } from "@shared/schema";
 import { useState, useEffect } from "react";

--- a/client/src/components/shopping-cart.tsx
+++ b/client/src/components/shopping-cart.tsx
@@ -11,11 +11,11 @@ import { getCategoryFallbackImage, getProductImage } from "@/lib/product-image-u
 type MoodKey = "good" | "normal" | "okay" | "sad" | "angry";
 
 const MOODS: Array<{ key: MoodKey; label: string; emoji: string; icon: typeof Smile }> = [
-  { key: "good", label: "Good", emoji: "😄", icon: Smile },
-  { key: "normal", label: "Normal", emoji: "🙂", icon: Smile },
-  { key: "okay", label: "Okay", emoji: "😐", icon: Meh },
-  { key: "sad", label: "Sad", emoji: "😔", icon: Frown },
-  { key: "angry", label: "Angry", emoji: "😠", icon: Angry },
+  { key: "good",   label: "Good",   emoji: "😄", icon: Smile  },
+  { key: "normal", label: "Normal", emoji: "🙂", icon: Smile  },
+  { key: "okay",   label: "Okay",   emoji: "😐", icon: Meh    },
+  { key: "sad",    label: "Sad",    emoji: "😔", icon: Frown  },
+  { key: "angry",  label: "Angry",  emoji: "😠", icon: Angry  },
 ];
 
 export default function ShoppingCart() {
@@ -25,249 +25,174 @@ export default function ShoppingCart() {
   const [mood, setMood] = useState<MoodKey>("good");
   const [feedbackReason, setFeedbackReason] = useState("");
   const [paymentReceipt, setPaymentReceipt] = useState<null | {
-    amount: number;
-    donation: number;
-    mood: MoodKey;
-    reason: string;
+    amount: number; donation: number; mood: MoodKey; reason: string;
   }>(null);
 
   useEffect(() => {
     if (!items.length) return;
-
     const artisanNames = Array.from(new Set(items.map((item) => item.product.artisanName)));
     setDonationByArtisan((prev) => {
       const next: Record<string, number> = {};
-      artisanNames.forEach((name) => {
-        next[name] = prev[name] ?? 1;
-      });
+      artisanNames.forEach((name) => { next[name] = prev[name] ?? 1; });
       return next;
     });
   }, [items]);
 
-  const donationTotal = useMemo(() => {
-    return Object.values(donationByArtisan).reduce((sum, val) => sum + val, 0);
-  }, [donationByArtisan]);
+  const donationTotal = useMemo(() =>
+    Object.values(donationByArtisan).reduce((sum, val) => sum + val, 0),
+  [donationByArtisan]);
 
   const grandTotal = total + donationTotal;
 
   const handleCheckout = async () => {
-    const filledLines = feedbackReason
-      .split("\n")
-      .map((line) => line.trim())
-      .filter(Boolean);
-
+    const filledLines = feedbackReason.split("\n").map((l) => l.trim()).filter(Boolean);
     if (filledLines.length < 3) {
-      toast({
-        title: "Add a little more feedback",
-        description: "Please write at least 3 lines in the reason box before payment.",
-        variant: "destructive",
-      });
+      toast({ title: "Add a little more feedback", description: "Please write at least 3 lines in the reason box before payment.", variant: "destructive" });
       return;
     }
-
     const currentDonation = donationTotal;
     const currentTotal = grandTotal;
     await clearCart();
-    setPaymentReceipt({
-      amount: currentTotal,
-      donation: currentDonation,
-      mood,
-      reason: feedbackReason,
-    });
+    setPaymentReceipt({ amount: currentTotal, donation: currentDonation, mood, reason: feedbackReason });
     setFeedbackReason("");
-
-    toast({
-      title: "Payment completed",
-      description: `Order placed successfully. Total paid $${currentTotal.toFixed(2)} including donation.`,
-    });
+    toast({ title: "Payment completed", description: `Order placed successfully. Total paid ${currentTotal.toFixed(2)} including donation.` });
   };
 
   return (
     <Sheet open={isOpen} onOpenChange={setIsOpen}>
-      <SheetContent className="w-96 sm:w-[400px]" data-testid="sheet-shopping-cart">
-        <SheetHeader>
+      <SheetContent className="w-96 sm:w-[400px] flex flex-col p-0" data-testid="sheet-shopping-cart">
+        {/* Header */}
+        <SheetHeader className="px-6 pt-6 pb-4 border-b border-border shrink-0">
           <SheetTitle className="flex items-center space-x-2">
             <ShoppingBag className="h-5 w-5" />
             <span>Shopping Cart</span>
           </SheetTitle>
         </SheetHeader>
-        
-        <div className="flex flex-col h-full">
-          <div className="flex-1 overflow-y-auto py-6">
-            {paymentReceipt && (
-              <div className="mb-4 rounded-lg border border-primary/30 bg-primary/5 p-4" data-testid="payment-receipt">
-                <p className="font-semibold text-foreground flex items-center">
-                  <Sparkles className="h-4 w-4 mr-2 text-primary" />
-                  Payment done successfully
-                </p>
-                <p className="text-sm text-muted-foreground mt-1">Paid: ${paymentReceipt.amount.toFixed(2)} (Donation: ${paymentReceipt.donation.toFixed(2)})</p>
-                <p className="text-sm mt-2">Mood: {MOODS.find((m) => m.key === paymentReceipt.mood)?.emoji} {MOODS.find((m) => m.key === paymentReceipt.mood)?.label}</p>
-                <p className="text-sm text-muted-foreground mt-2 whitespace-pre-line">{paymentReceipt.reason}</p>
-              </div>
-            )}
 
-            {items.length === 0 ? (
-              <div className="text-center py-12">
-                <ShoppingBag className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
-                <p className="text-muted-foreground" data-testid="text-empty-cart">Your cart is empty</p>
-              </div>
-            ) : (
+        {/* Scrollable content */}
+        <div className="flex-1 overflow-y-auto px-6 py-4 space-y-4">
+          {paymentReceipt && (
+            <div className="rounded-lg border border-primary/30 bg-primary/5 p-4" data-testid="payment-receipt">
+              <p className="font-semibold text-foreground flex items-center">
+                <Sparkles className="h-4 w-4 mr-2 text-primary" />
+                Payment done successfully
+              </p>
+              <p className="text-sm text-muted-foreground mt-1">Paid: ${paymentReceipt.amount.toFixed(2)} (Donation: ${paymentReceipt.donation.toFixed(2)})</p>
+              <p className="text-sm mt-2">Mood: {MOODS.find((m) => m.key === paymentReceipt.mood)?.emoji} {MOODS.find((m) => m.key === paymentReceipt.mood)?.label}</p>
+              <p className="text-sm text-muted-foreground mt-2 whitespace-pre-line">{paymentReceipt.reason}</p>
+            </div>
+          )}
+
+          {items.length === 0 ? (
+            <div className="text-center py-12">
+              <ShoppingBag className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
+              <p className="text-muted-foreground" data-testid="text-empty-cart">Your cart is empty</p>
+            </div>
+          ) : (
+            <>
+              {/* Cart items */}
               <div className="space-y-4">
                 {items.map((item) => (
                   <div key={item.id} className="flex items-center space-x-4 p-4 border border-border rounded-lg" data-testid={`cart-item-${item.id}`}>
-                    <img 
-                      src={getProductImage(item.product)} 
+                    <img
+                      src={getProductImage(item.product)}
                       alt={item.product.name}
                       className="w-16 h-16 object-cover rounded-lg"
-                      onError={(e) => {
-                        const img = e.currentTarget;
-                        img.onerror = null;
-                        img.src = getCategoryFallbackImage(undefined, item.product.id || item.id, 2);
-                      }}
+                      onError={(e) => { const img = e.currentTarget; img.onerror = null; img.src = getCategoryFallbackImage(undefined, item.product.id || item.id, 2); }}
                     />
                     <div className="flex-1">
-                      <h4 className="font-medium text-sm" data-testid={`text-item-name-${item.id}`}>
-                        {item.product.name}
-                      </h4>
-                      <p className="text-xs text-muted-foreground" data-testid={`text-item-artisan-${item.id}`}>
-                        by {item.product.artisanName}
-                      </p>
+                      <h4 className="font-medium text-sm" data-testid={`text-item-name-${item.id}`}>{item.product.name}</h4>
+                      <p className="text-xs text-muted-foreground" data-testid={`text-item-artisan-${item.id}`}>by {item.product.artisanName}</p>
                       <div className="flex items-center justify-between mt-2">
-                        <span className="text-primary font-bold" data-testid={`text-item-price-${item.id}`}>
-                          ${item.product.price}
-                        </span>
+                        <span className="text-primary font-bold" data-testid={`text-item-price-${item.id}`}>${item.product.price}</span>
                         <div className="flex items-center space-x-2">
-                          <Button
-                            variant="outline"
-                            size="icon"
-                            onClick={() => updateQuantity(item.id, Math.max(1, item.quantity - 1))}
-                            className="h-6 w-6"
-                            data-testid={`button-decrease-${item.id}`}
-                          >
-                            <Minus className="h-3 w-3" />
-                          </Button>
-                          <span className="text-sm font-medium w-8 text-center" data-testid={`text-item-quantity-${item.id}`}>
-                            {item.quantity}
-                          </span>
-                          <Button
-                            variant="outline"
-                            size="icon"
-                            onClick={() => updateQuantity(item.id, item.quantity + 1)}
-                            className="h-6 w-6"
-                            data-testid={`button-increase-${item.id}`}
-                          >
-                            <Plus className="h-3 w-3" />
-                          </Button>
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            onClick={() => removeFromCart(item.id)}
-                            className="h-6 w-6 text-destructive hover:text-destructive"
-                            data-testid={`button-remove-${item.id}`}
-                          >
-                            <X className="h-3 w-3" />
-                          </Button>
+                          <Button variant="outline" size="icon" onClick={() => updateQuantity(item.id, Math.max(1, item.quantity - 1))} className="h-6 w-6" data-testid={`button-decrease-${item.id}`}><Minus className="h-3 w-3" /></Button>
+                          <span className="text-sm font-medium w-8 text-center" data-testid={`text-item-quantity-${item.id}`}>{item.quantity}</span>
+                          <Button variant="outline" size="icon" onClick={() => updateQuantity(item.id, item.quantity + 1)} className="h-6 w-6" data-testid={`button-increase-${item.id}`}><Plus className="h-3 w-3" /></Button>
+                          <Button variant="ghost" size="icon" onClick={() => removeFromCart(item.id)} className="h-6 w-6 text-destructive hover:text-destructive" data-testid={`button-remove-${item.id}`}><X className="h-3 w-3" /></Button>
                         </div>
                       </div>
                     </div>
                   </div>
                 ))}
               </div>
-            )}
-          </div>
 
-          {items.length > 0 && (
-            <>
-              <Separator className="my-4" />
-              <div className="space-y-5 pb-4">
-                <div className="rounded-lg border border-border p-3">
-                  <p className="text-sm font-semibold flex items-center mb-2">
-                    <HeartHandshake className="h-4 w-4 mr-2 text-primary" />
-                    Donate to artisans ($1 to $10 each)
-                  </p>
-                  <div className="space-y-3">
-                    {Object.entries(donationByArtisan).map(([artisanName, value]) => (
-                      <div key={artisanName} className="space-y-1">
-                        <div className="flex items-center justify-between text-xs">
-                          <span className="text-muted-foreground">{artisanName}</span>
-                          <span className="font-semibold text-primary">${value}</span>
-                        </div>
-                        <input
-                          type="range"
-                          min={1}
-                          max={10}
-                          step={1}
-                          value={value}
-                          onChange={(e) => {
-                            const next = Number(e.target.value);
-                            setDonationByArtisan((prev) => ({ ...prev, [artisanName]: next }));
-                          }}
-                          className="w-full"
-                        />
+              {/* Donation */}
+              <div className="rounded-lg border border-border p-3">
+                <p className="text-sm font-semibold flex items-center mb-2">
+                  <HeartHandshake className="h-4 w-4 mr-2 text-primary" />
+                  Donate to artisans ($1 to $10 each)
+                </p>
+                <div className="space-y-3">
+                  {Object.entries(donationByArtisan).map(([artisanName, value]) => (
+                    <div key={artisanName} className="space-y-1">
+                      <div className="flex items-center justify-between text-xs">
+                        <span className="text-muted-foreground">{artisanName}</span>
+                        <span className="font-semibold text-primary">${value}</span>
                       </div>
-                    ))}
-                  </div>
+                      <input type="range" min={1} max={10} step={1} value={value}
+                        onChange={(e) => { const next = Number(e.target.value); setDonationByArtisan((prev) => ({ ...prev, [artisanName]: next })); }}
+                        className="w-full" />
+                    </div>
+                  ))}
                 </div>
+              </div>
 
-                <div className="rounded-lg border border-border p-3">
-                  <p className="text-sm font-semibold mb-2">How do you feel about this order?</p>
-                  <div className="grid grid-cols-5 gap-1">
-                    {MOODS.map((item) => {
-                      const Icon = item.icon;
-                      const active = mood === item.key;
-                      return (
-                        <Button
-                          key={item.key}
-                          variant={active ? "default" : "outline"}
-                          size="sm"
-                          onClick={() => setMood(item.key)}
-                          className="h-auto py-2 px-1 flex flex-col gap-1"
-                        >
-                          <span>{item.emoji}</span>
-                          <span className="text-[10px] leading-none">{item.label}</span>
-                          <Icon className="h-3 w-3" />
-                        </Button>
-                      );
-                    })}
-                  </div>
+              {/* Mood */}
+              <div className="rounded-lg border border-border p-3">
+                <p className="text-sm font-semibold mb-2">How do you feel about this order?</p>
+                <div className="grid grid-cols-5 gap-1">
+                  {MOODS.map((item) => {
+                    const Icon = item.icon;
+                    const active = mood === item.key;
+                    return (
+                      <Button key={item.key} variant={active ? "default" : "outline"} size="sm"
+                        onClick={() => setMood(item.key)} className="h-auto py-2 px-1 flex flex-col gap-1">
+                        <span>{item.emoji}</span>
+                        <span className="text-[10px] leading-none">{item.label}</span>
+                        <Icon className="h-3 w-3" />
+                      </Button>
+                    );
+                  })}
                 </div>
+              </div>
 
-                <div className="rounded-lg border border-border p-3">
-                  <p className="text-sm font-semibold mb-2">Why this feeling? (min 3 lines)</p>
-                  <Textarea
-                    rows={4}
-                    placeholder={"Line 1: What you liked\nLine 2: What can improve\nLine 3: Why you chose this mood"}
-                    value={feedbackReason}
-                    onChange={(e) => setFeedbackReason(e.target.value)}
-                    data-testid="textarea-feedback-reason"
-                  />
-                </div>
-
-                <div className="flex justify-between items-center">
-                  <span className="text-sm text-muted-foreground">Subtotal</span>
-                  <span className="font-semibold">${total.toFixed(2)}</span>
-                </div>
-                <div className="flex justify-between items-center">
-                  <span className="text-sm text-muted-foreground">Donation</span>
-                  <span className="font-semibold text-primary">${donationTotal.toFixed(2)}</span>
-                </div>
-                <div className="flex justify-between items-center">
-                  <span className="font-semibold">Total:</span>
-                  <span className="text-xl font-bold text-primary" data-testid="text-cart-total">
-                    ${grandTotal.toFixed(2)}
-                  </span>
-                </div>
-                <Button 
-                  className="w-full bg-primary text-primary-foreground hover:bg-primary/90"
-                  onClick={handleCheckout}
-                  data-testid="button-checkout"
-                >
-                  Pay Now
-                </Button>
+              {/* Feedback */}
+              <div className="rounded-lg border border-border p-3">
+                <p className="text-sm font-semibold mb-2">Why this feeling? (min 3 lines)</p>
+                <Textarea rows={4}
+                  placeholder={"Line 1: What you liked\nLine 2: What can improve\nLine 3: Why you chose this mood"}
+                  value={feedbackReason} onChange={(e) => setFeedbackReason(e.target.value)}
+                  data-testid="textarea-feedback-reason" />
               </div>
             </>
           )}
         </div>
+
+        {/* Sticky bottom — totals + buttons */}
+        {items.length > 0 && (
+          <div className="shrink-0 px-6 pb-6 pt-4 border-t border-border bg-background space-y-3">
+            <div className="flex justify-between items-center text-sm">
+              <span className="text-muted-foreground">Subtotal</span>
+              <span className="font-semibold">${total.toFixed(2)}</span>
+            </div>
+            <div className="flex justify-between items-center text-sm">
+              <span className="text-muted-foreground">Donation</span>
+              <span className="font-semibold text-primary">${donationTotal.toFixed(2)}</span>
+            </div>
+            <div className="flex justify-between items-center">
+              <span className="font-semibold">Total</span>
+              <span className="text-xl font-bold text-primary" data-testid="text-cart-total">${grandTotal.toFixed(2)}</span>
+            </div>
+            <Separator />
+            <Button className="w-full bg-primary text-primary-foreground hover:bg-primary/90" onClick={handleCheckout} data-testid="button-checkout">
+              Pay Now
+            </Button>
+            <Button variant="outline" className="w-full" onClick={() => { setIsOpen(false); window.location.href = "/checkout"; }} data-testid="button-go-to-checkout">
+              Proceed to Checkout Page
+            </Button>
+          </div>
+        )}
       </SheetContent>
     </Sheet>
   );

--- a/client/src/context/auth-context.tsx
+++ b/client/src/context/auth-context.tsx
@@ -1,7 +1,5 @@
 import { createContext, useContext, useState } from "react";
 
-// ─── Types ───────────────────────────────────────────────────────────────────
-
 type UserType = "artisan" | "customer";
 
 interface AuthContextType {
@@ -12,8 +10,6 @@ interface AuthContextType {
   logout:     () => void;
 }
 
-// ─── Context ─────────────────────────────────────────────────────────────────
-
 const AuthContext = createContext<AuthContextType | null>(null);
 
 export function useAuth(): AuthContextType {
@@ -22,24 +18,16 @@ export function useAuth(): AuthContextType {
   return ctx;
 }
 
-// ─── Provider ────────────────────────────────────────────────────────────────
-
 export function AuthProvider({ children }: { children: React.ReactNode }) {
-
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
-  const [userType,   setUserType]   = useState<UserType | null>(null);
-  const [userName,   setUserName]   = useState<string | null>(null);
-
   const [isLoggedIn, setIsLoggedIn] = useState<boolean>(() => {
     return localStorage.getItem("auth_logged_in") === "true";
   });
-  const [userType, setUserType] = useState<"artisan" | "customer" | null>(() => {
-    return (localStorage.getItem("auth_user_type") as "artisan" | "customer") || null;
+  const [userType, setUserType] = useState<UserType | null>(() => {
+    return (localStorage.getItem("auth_user_type") as UserType) || null;
   });
   const [userName, setUserName] = useState<string | null>(() => {
     return localStorage.getItem("auth_user_name") || null;
   });
-
 
   const login = (type: UserType, name: string) => {
     setIsLoggedIn(true);

--- a/client/src/context/cart-context.tsx
+++ b/client/src/context/cart-context.tsx
@@ -1,11 +1,11 @@
-
-import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 import { createContext, useContext, useState, useEffect } from "react";
 import { api } from "@/lib/api";
 import { CartContextType, CartItemWithProduct } from "@/types";
 
 const CartContext = createContext<CartContextType | null>(null);
 
+const CART_SESSION_KEY = "artisan-collective-cart-session";
+const CART_CACHE_KEY   = "artisan-collective-cart-cache";
 
 export function useCart(): CartContextType {
   const ctx = useContext(CartContext);
@@ -17,143 +17,60 @@ export function CartProvider({ children }: { children: React.ReactNode }) {
   const [items,  setItems]  = useState<CartItemWithProduct[]>([]);
   const [isOpen, setIsOpen] = useState(false);
 
-  const sessionId = useRef(
-    localStorage.getItem("cart-session") ?? crypto.randomUUID()
-  ).current;
-
-  const loadCart = useCallback(async () => {
-    try {
-      const cartItems = await api.getCartItems(sessionId);
-      const fullItems = await Promise.all(
-        cartItems.map(async (item: any) => {
-          const product = await api.getProduct(item.productId);
-          const artisan = await api.getArtisan(product.artisanId);
-          return { ...item, product: { ...product, artisanName: artisan.name } };
-        })
-      );
-      setItems(fullItems);
-    } catch (err) {
-      console.error("Failed to load cart:", err);
-    }
-  }, [sessionId]);
-
-  useEffect(() => { loadCart(); }, [loadCart]);
-
-  const addToCart = useCallback(async (productId: string) => {
-    try {
-      await api.addToCart({ sessionId, productId, quantity: 1 });
-      await loadCart();
-      setIsOpen(true);
-    } catch (err) { console.error(err); }
-  }, [sessionId, loadCart]);
-
-  const updateQuantity = useCallback(async (id: string, quantity: number) => {
-    try {
-      await api.updateCartItem(id, quantity);
-      await loadCart();
-    } catch (err) { console.error(err); }
-  }, [loadCart]);
-
-  const removeFromCart = useCallback(async (id: string) => {
-    try {
-      await api.removeFromCart(id);
-      await loadCart();
-    } catch (err) { console.error(err); }
-  }, [loadCart]);
-
-  const clearCart = useCallback(async () => {
-    try {
-      await api.clearCart(sessionId);
-      setItems([]);
-    } catch (err) { console.error(err); }
-  }, [sessionId]);
-
-  const total    = useMemo(() => items.reduce((sum, i) => sum + Number(i.product.price) * i.quantity, 0), [items]);
-  const itemCount = useMemo(() => items.reduce((sum, i) => sum + i.quantity, 0), [items]);
-
-const CART_SESSION_STORAGE_KEY = "artisan-collective-cart-session";
-const CART_CACHE_STORAGE_KEY = "artisan-collective-cart-cache";
-
-export const useCart = () => {
-  const context = useContext(CartContext);
-  if (!context) {
-    throw new Error("useCart must be used within CartProvider");
-  }
-  return context;
-};
-
-export function CartProvider({ children }: { children: React.ReactNode }) {
-  const [items, setItems] = useState<CartItemWithProduct[]>([]);
-  const [isOpen, setIsOpen] = useState(false);
   const [sessionId] = useState(() => {
-    if (typeof window === "undefined") return "guest-session";
-    const existing = window.localStorage.getItem(CART_SESSION_STORAGE_KEY);
+    const existing = window.localStorage.getItem(CART_SESSION_KEY);
     if (existing) return existing;
     const generated = `guest-${crypto.randomUUID()}`;
-    window.localStorage.setItem(CART_SESSION_STORAGE_KEY, generated);
+    window.localStorage.setItem(CART_SESSION_KEY, generated);
     return generated;
   });
 
-  const writeCartCache = (nextItems: CartItemWithProduct[]) => {
-    if (typeof window === "undefined") return;
-    window.localStorage.setItem(CART_CACHE_STORAGE_KEY, JSON.stringify(nextItems));
-  };
+  const writeCache = (next: CartItemWithProduct[]) =>
+    window.localStorage.setItem(CART_CACHE_KEY, JSON.stringify(next));
 
-  const readCartCache = (): CartItemWithProduct[] => {
-    if (typeof window === "undefined") return [];
-    const raw = window.localStorage.getItem(CART_CACHE_STORAGE_KEY);
-    if (!raw) return [];
+  const readCache = (): CartItemWithProduct[] => {
     try {
-      const parsed = JSON.parse(raw);
-      if (!Array.isArray(parsed)) return [];
-      return parsed as CartItemWithProduct[];
-    } catch {
-      return [];
-    }
+      const raw = window.localStorage.getItem(CART_CACHE_KEY);
+      const parsed = raw ? JSON.parse(raw) : [];
+      return Array.isArray(parsed) ? parsed : [];
+    } catch { return []; }
   };
 
-  const hydrateWithProducts = async (cartItems: Array<{ id: string; productId: string; quantity: number }>) => {
-    return Promise.all(
+  const hydrate = async (cartItems: Array<{ id: string; productId: string; quantity: number }>) =>
+    Promise.all(
       cartItems.map(async (item) => {
         const product = await api.getProduct(item.productId);
         const artisan = await api.getArtisan(product.artisanId);
         return { ...item, product: { ...product, artisanName: artisan.name } };
       })
     );
-  };
 
   const loadCart = async () => {
     try {
       const cartItems = await api.getCartItems(sessionId);
-      let itemsWithProducts = await hydrateWithProducts(cartItems);
+      let withProducts = await hydrate(cartItems);
 
-      if (itemsWithProducts.length === 0) {
-        const cachedItems = readCartCache();
-        if (cachedItems.length > 0) {
-          for (const cachedItem of cachedItems) {
-            await api.addToCart({
-              sessionId,
-              productId: cachedItem.productId,
-              quantity: Math.max(1, Number(cachedItem.quantity) || 1),
-            });
+      if (withProducts.length === 0) {
+        const cached = readCache();
+        if (cached.length > 0) {
+          for (const c of cached) {
+            await api.addToCart({ sessionId, productId: c.productId, quantity: Math.max(1, Number(c.quantity) || 1) });
           }
-          const restoredItems = await api.getCartItems(sessionId);
-          itemsWithProducts = await hydrateWithProducts(restoredItems);
+          withProducts = await hydrate(await api.getCartItems(sessionId));
         }
       }
 
-      setItems(itemsWithProducts);
-      writeCartCache(itemsWithProducts);
-    } catch (error) {
-      console.error("Failed to load cart:", error);
-      const cachedItems = readCartCache();
-      if (cachedItems.length > 0) setItems(cachedItems);
+      setItems(withProducts);
+      writeCache(withProducts);
+    } catch {
+      const cached = readCache();
+      if (cached.length > 0) setItems(cached);
     }
   };
 
   useEffect(() => {
-    const cachedItems = readCartCache();
-    if (cachedItems.length > 0) setItems(cachedItems);
+    const cached = readCache();
+    if (cached.length > 0) setItems(cached);
     loadCart();
   }, []);
 
@@ -176,15 +93,15 @@ export function CartProvider({ children }: { children: React.ReactNode }) {
   const clearCart = async () => {
     await api.clearCart(sessionId);
     setItems([]);
-    writeCartCache([]);
+    writeCache([]);
   };
 
-  const total = items.reduce((sum, item) => sum + parseFloat(item.product.price) * item.quantity, 0);
-  const itemCount = items.reduce((sum, item) => sum + item.quantity, 0);
+  const total     = items.reduce((sum, i) => sum + parseFloat(i.product.price) * i.quantity, 0);
+  const itemCount = items.reduce((sum, i) => sum + i.quantity, 0);
 
   return (
     <CartContext.Provider value={{ items, addToCart, updateQuantity, removeFromCart, clearCart, total, itemCount, isOpen, setIsOpen }}>
       {children}
     </CartContext.Provider>
   );
-
+}

--- a/client/src/pages/checkout.tsx
+++ b/client/src/pages/checkout.tsx
@@ -1,0 +1,278 @@
+import { useState } from "react";
+import type { ChangeEvent } from "react";
+import { useLocation } from "wouter";
+import { ShoppingBag, MapPin, CreditCard, CheckCircle, Trash2, ArrowLeft } from "lucide-react";
+import { useCart } from "@/context/cart-context";
+import { useAuth } from "@/context/auth-context";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+import { useToast } from "@/hooks/use-toast";
+import { getProductImage, getCategoryFallbackImage } from "@/lib/product-image-utils";
+
+type Step = "summary" | "address" | "payment" | "confirmed";
+
+interface AddressForm {
+  fullName: string;
+  phone: string;
+  addressLine1: string;
+  addressLine2: string;
+  city: string;
+  state: string;
+  pincode: string;
+}
+
+const EMPTY_ADDRESS: AddressForm = {
+  fullName: "", phone: "", addressLine1: "",
+  addressLine2: "", city: "", state: "", pincode: "",
+};
+
+export default function Checkout() {
+  const [, navigate] = useLocation();
+  const { items, total, itemCount, removeFromCart, clearCart } = useCart();
+  const { isLoggedIn, userName } = useAuth();
+  const { toast } = useToast();
+
+  const [step, setStep] = useState<Step>("summary");
+  const [address, setAddress] = useState<AddressForm>({
+    ...EMPTY_ADDRESS,
+    fullName: userName ?? "",
+  });
+  const [orderId] = useState(`ORD-${Math.random().toString(36).substr(2, 9).toUpperCase()}`);
+
+  const tax = total * 0.05;
+  const grandTotal = total + tax;
+
+  // ── helpers ────────────────────────────────────────────────────────────────
+
+  const handleAddressChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setAddress((prev) => ({ ...prev, [e.target.name]: e.target.value }));
+  };
+
+  const isAddressValid = () =>
+    address.fullName.trim() &&
+    address.phone.trim() &&
+    address.addressLine1.trim() &&
+    address.city.trim() &&
+    address.state.trim() &&
+    address.pincode.trim();
+
+  const handlePlaceOrder = async () => {
+    await clearCart();
+    setStep("confirmed");
+    toast({ title: "Order placed!", description: `Your order ${orderId} is confirmed.` });
+  };
+
+  // ── empty cart guard ───────────────────────────────────────────────────────
+
+  if (items.length === 0 && step !== "confirmed") {
+    return (
+      <div className="container mx-auto px-4 py-24 text-center">
+        <ShoppingBag className="h-16 w-16 mx-auto text-muted-foreground mb-4" />
+        <h2 className="text-2xl font-serif font-bold mb-2">Your cart is empty</h2>
+        <p className="text-muted-foreground mb-6">Add some products before checking out.</p>
+        <Button onClick={() => navigate("/marketplace")}>Browse Marketplace</Button>
+      </div>
+    );
+  }
+
+  // ── step: confirmed ────────────────────────────────────────────────────────
+
+  if (step === "confirmed") {
+    return (
+      <div className="container mx-auto px-4 py-24 max-w-lg text-center">
+        <CheckCircle className="h-20 w-20 mx-auto text-green-500 mb-6" />
+        <h1 className="text-3xl font-serif font-bold mb-2">Order Confirmed!</h1>
+        <p className="text-muted-foreground mb-1">Thank you for supporting local artisans.</p>
+        <p className="text-sm font-mono text-primary mb-8">{orderId}</p>
+        <Card className="text-left mb-6">
+          <CardContent className="p-6 space-y-2 text-sm">
+            <div className="flex justify-between"><span className="text-muted-foreground">Delivered to</span><span className="font-medium">{address.fullName}</span></div>
+            <div className="flex justify-between"><span className="text-muted-foreground">Address</span><span className="font-medium text-right max-w-[60%]">{address.addressLine1}, {address.city}</span></div>
+            <div className="flex justify-between"><span className="text-muted-foreground">Amount paid</span><span className="font-bold text-primary">₹{grandTotal.toFixed(2)}</span></div>
+          </CardContent>
+        </Card>
+        <Button className="w-full" onClick={() => navigate("/marketplace")}>Continue Shopping</Button>
+      </div>
+    );
+  }
+
+  // ── main layout ────────────────────────────────────────────────────────────
+
+  return (
+    <div className="container mx-auto px-4 sm:px-6 lg:px-8 py-10">
+      {/* breadcrumb */}
+      <button
+        onClick={() => step === "summary" ? navigate("/marketplace") : setStep(step === "payment" ? "address" : "summary")}
+        className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground mb-8 transition-colors"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        {step === "summary" ? "Back to Marketplace" : "Back"}
+      </button>
+
+      {/* step indicator */}
+      <div className="flex items-center gap-2 mb-10 text-xs font-semibold uppercase tracking-wider">
+        {(["summary", "address", "payment"] as Step[]).map((s, i) => (
+          <div key={s} className="flex items-center gap-2">
+            <span className={`w-6 h-6 rounded-full flex items-center justify-center text-[10px] font-bold
+              ${step === s ? "bg-primary text-primary-foreground" :
+                ["summary","address","payment"].indexOf(step) > i ? "bg-green-500 text-white" : "bg-muted text-muted-foreground"}`}>
+              {i + 1}
+            </span>
+            <span className={step === s ? "text-foreground" : "text-muted-foreground"}>{s}</span>
+            {i < 2 && <span className="text-muted-foreground mx-1">›</span>}
+          </div>
+        ))}
+      </div>
+
+      <div className="grid lg:grid-cols-3 gap-8">
+        {/* ── left panel ── */}
+        <div className="lg:col-span-2 space-y-6">
+
+          {/* STEP 1 — Order Summary */}
+          {step === "summary" && (
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-lg">
+                  <ShoppingBag className="h-5 w-5" /> Order Summary ({itemCount} items)
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                {items.map((item) => {
+                  const img = getProductImage(item.product, 0);
+                  return (
+                    <div key={item.id} className="flex gap-4 items-start">
+                      <img src={img} alt={item.product.name}
+                        className="w-16 h-16 rounded-lg object-cover border border-border flex-shrink-0"
+                        onError={(e) => { const t = e.currentTarget; t.onerror = null; t.src = getCategoryFallbackImage("default", item.productId, 1); }} />
+                      <div className="flex-1 min-w-0">
+                        <p className="font-medium text-sm truncate">{item.product.name}</p>
+                        <p className="text-xs text-muted-foreground">by {item.product.artisanName}</p>
+                        <p className="text-xs text-muted-foreground mt-1">Qty: {item.quantity}</p>
+                      </div>
+                      <div className="text-right flex-shrink-0">
+                        <p className="font-semibold text-sm">₹{(parseFloat(item.product.price) * item.quantity).toFixed(2)}</p>
+                        <button onClick={() => removeFromCart(item.id)}
+                          className="text-destructive hover:text-destructive/80 mt-1 transition-colors">
+                          <Trash2 className="h-3.5 w-3.5" />
+                        </button>
+                      </div>
+                    </div>
+                  );
+                })}
+                <Separator />
+                <Button className="w-full" onClick={() => setStep("address")}>
+                  Proceed to Delivery Address
+                </Button>
+              </CardContent>
+            </Card>
+          )}
+
+          {/* STEP 2 — Delivery Address */}
+          {step === "address" && (
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-lg">
+                  <MapPin className="h-5 w-5" /> Delivery Address
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="grid grid-cols-2 gap-4">
+                  <div className="col-span-2">
+                    <label className="text-xs font-medium text-muted-foreground mb-1 block">Full Name *</label>
+                    <Input name="fullName" value={address.fullName} onChange={handleAddressChange} placeholder="Your full name" />
+                  </div>
+                  <div className="col-span-2">
+                    <label className="text-xs font-medium text-muted-foreground mb-1 block">Phone Number *</label>
+                    <Input name="phone" value={address.phone} onChange={handleAddressChange} placeholder="+91 XXXXX XXXXX" />
+                  </div>
+                  <div className="col-span-2">
+                    <label className="text-xs font-medium text-muted-foreground mb-1 block">Address Line 1 *</label>
+                    <Input name="addressLine1" value={address.addressLine1} onChange={handleAddressChange} placeholder="House / Flat / Street" />
+                  </div>
+                  <div className="col-span-2">
+                    <label className="text-xs font-medium text-muted-foreground mb-1 block">Address Line 2</label>
+                    <Input name="addressLine2" value={address.addressLine2} onChange={handleAddressChange} placeholder="Landmark (optional)" />
+                  </div>
+                  <div>
+                    <label className="text-xs font-medium text-muted-foreground mb-1 block">City *</label>
+                    <Input name="city" value={address.city} onChange={handleAddressChange} placeholder="City" />
+                  </div>
+                  <div>
+                    <label className="text-xs font-medium text-muted-foreground mb-1 block">State *</label>
+                    <Input name="state" value={address.state} onChange={handleAddressChange} placeholder="State" />
+                  </div>
+                  <div>
+                    <label className="text-xs font-medium text-muted-foreground mb-1 block">Pincode *</label>
+                    <Input name="pincode" value={address.pincode} onChange={handleAddressChange} placeholder="6-digit pincode" maxLength={6} />
+                  </div>
+                </div>
+                <Button className="w-full" disabled={!isAddressValid()} onClick={() => setStep("payment")}>
+                  Proceed to Payment
+                </Button>
+              </CardContent>
+            </Card>
+          )}
+
+          {/* STEP 3 — Payment */}
+          {step === "payment" && (
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-lg">
+                  <CreditCard className="h-5 w-5" /> Payment
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="rounded-lg border border-border bg-muted/30 p-4 text-sm text-muted-foreground text-center">
+                  <CreditCard className="h-8 w-8 mx-auto mb-2 text-primary" />
+                  <p className="font-medium text-foreground">Demo Checkout</p>
+                  <p className="text-xs mt-1">Payment gateway integration coming soon. Click below to simulate a successful order.</p>
+                </div>
+                <Separator />
+                <div className="space-y-1 text-sm">
+                  <div className="flex justify-between text-muted-foreground"><span>Delivering to</span><span className="font-medium text-foreground">{address.fullName}</span></div>
+                  <div className="flex justify-between text-muted-foreground"><span>{address.addressLine1}, {address.city}</span></div>
+                </div>
+                <Button className="w-full bg-green-600 hover:bg-green-700 text-white" onClick={handlePlaceOrder}>
+                  Place Order · ₹{grandTotal.toFixed(2)}
+                </Button>
+              </CardContent>
+            </Card>
+          )}
+        </div>
+
+        {/* ── right panel — price breakdown ── */}
+        <div className="space-y-4">
+          <Card className="sticky top-24">
+            <CardHeader>
+              <CardTitle className="text-base">Price Breakdown</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3 text-sm">
+              {items.map((item) => (
+                <div key={item.id} className="flex justify-between text-muted-foreground">
+                  <span className="truncate max-w-[65%]">{item.product.name} × {item.quantity}</span>
+                  <span>₹{(parseFloat(item.product.price) * item.quantity).toFixed(2)}</span>
+                </div>
+              ))}
+              <Separator />
+              <div className="flex justify-between text-muted-foreground">
+                <span>Subtotal</span><span>₹{total.toFixed(2)}</span>
+              </div>
+              <div className="flex justify-between text-muted-foreground">
+                <span>GST (5%)</span><span>₹{tax.toFixed(2)}</span>
+              </div>
+              <div className="flex justify-between text-muted-foreground">
+                <span>Shipping</span><span className="text-green-600 font-medium">Free</span>
+              </div>
+              <Separator />
+              <div className="flex justify-between font-bold text-base">
+                <span>Total</span><span className="text-primary">₹{grandTotal.toFixed(2)}</span>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #15 

## What's added
- New `/checkout` page with a 3-step flow: Order Summary → Delivery Address → Payment → Confirmation
- Step indicator showing progress
- Order summary with product images, names, artisan, quantity, and remove option
- Delivery address form with validation (required fields must be filled before proceeding)
- Payment step with order recap and place order button
- Order confirmation screen with unique order ID
- "Proceed to Checkout Page" button added to the cart sidebar (always visible, pinned at bottom)
- Fixed pre-existing duplicate import bugs in `auth-context.tsx`, `cart-context.tsx`, `App.tsx`, and `navbar.tsx`

NSoC'26
